### PR TITLE
Allow more parity shards than data shards

### DIFF
--- a/rs.c
+++ b/rs.c
@@ -82,7 +82,7 @@ void reed_solomon_init(void)
 reed_solomon *reed_solomon_new(int ds, int ps)
 {
     reed_solomon *rs = NULL;
-    if ((ds + ps) > DATA_SHARDS_MAX || ds <= 0 || ps <= 0 || ps > ds)
+    if ((ds + ps) > DATA_SHARDS_MAX || ds <= 0 || ps <= 0)
         return NULL;
     rs = calloc(1, sizeof(reed_solomon) + 2 * ps * ds);
     if (!rs)


### PR DESCRIPTION
## Description
This check breaks the case where we boost the number of parity shards to meet the client's requested parity shard minimum.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
